### PR TITLE
feat: add git alias swo mean git checkout origin/master

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -8,11 +8,11 @@
        c  = commit
        cv = commit -v
        co = checkout
-       coo = checkout origin/master
        di = diff
        dc = diff --cached
        st = status
        sw = switch
+       swo= switch -d origin/master
 
        # alias
        cancel = reset --soft HEAD^


### PR DESCRIPTION
ローカルの master を削除した運用で checkout を使うと、
git checkout origin/master するたびに switch を使えってうるさいので
coo をやめて swo に移行することにした。
-d は detach 上等で所定のブランチに HEAD を移せるっぽい