### PR TITLE
feat: fix tmux.conf for v2.x later

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -4,23 +4,16 @@ bind-key C-z send-prefix
 unbind-key C-b
 
 # terminal
-set-option -g utf8 on
-set-window-option -g utf8 on
-set-option -g status-utf8 on
 set-option -g default-terminal xterm-256color
 #set-option -g default-terminal screen-256color
 set-option -g history-limit 10000
 #set-option -g status-interval 5
 
 # status color
-set-option -g message-fg white
-set-option -g message-bg red
-set-option -g status-fg black
-set-option -g status-bg cyan
-set-window-option -g window-status-fg black
-set-window-option -g window-status-bg cyan
-set-window-option -g window-status-current-fg blue
-set-window-option -g window-status-current-bg black
+set -g message-style "bg=red,fg=white"
+set -g status-style "bg=cyan,fg=black"
+set -g window-status-style "bg=cyan,fg=black"
+set -g window-status-current-style "bg=black,fg=blue"
 
 # key
 


### PR DESCRIPTION
MacBook Pro の iTerm2 で tmux 起動するとエラーが表示されるの
気になるから設定直し。
家のPCで問題でるようなら tmux のバージョンアップをすること。