### PR TITLE
fix: git alias / origin/master to origin/HEAD

### DIFF
--- a/alias
+++ b/alias
@@ -27,8 +27,8 @@ alias gdi='git diff'
 alias gf='git fetch --prune'
 alias gg='git grep -i -P'
 alias gp='git plog -10'
-alias gr='git fetch --prune --all && git checkout origin/master && git plog -10 && git status'
-alias gs='git switch -d origin/master'
+alias gr='git fetch --prune --all && git checkout origin/HEAD && git plog -10 && git status'
+alias gs='git switch -d origin/HEAD'
 alias gst='git status'
 
 # k8s


### PR DESCRIPTION
GitHub のデフォルトブランチが master から main に変わっていくので、
alias にしていた origin/master を origin/HEAD にすることで、
デフォルトブランチに向くようにした。

これで master でも main でも develop でも問題ない（はず）