### PR TITLE
feat: add Include statement in ssh_config, docker alias al2

### DIFF
--- a/alias
+++ b/alias
@@ -13,6 +13,7 @@ alias dl='docker logs'
 alias dps='docker ps'
 alias ds='docker stop'
 alias dri='docker run -itd --rm '
+alias al2='docker run -itd --rm --name al2 amazonlinux'
 alias alpinx='docker run -itd --rm -v `pwd`:/usr/share/nginx/html -p 8081:80 --name alpinx nginx:alpine'
 alias alpython='docker run --rm -it -d --name alpython python:alpine'
 

--- a/ssh_config
+++ b/ssh_config
@@ -1,4 +1,7 @@
 # .ssh/config
+
+# Include conf.d/*
+
 Host xxx-* yyy-*
     # ホスト接続時に違うユーザとして接続
     # User user_account


### PR DESCRIPTION
ssh config が肥大化してるので分割を始めた。
dotfile 的には Include 文をコメントで書いておくだけにした。

al2 は docker で Amazon Linux2 をちょっといじりたい時用。
（一緒にコミットすんなよｗ）