### PR TITLE
feat: alias tree --charset unicode

### DIFF
--- a/alias
+++ b/alias
@@ -2,6 +2,7 @@
 
 # command
 alias ll='ls -l'
+alias tree='tree --charset unicode'
 
 # boundary 
 alias b='boundary'


### PR DESCRIPTION
tree コマンドの実行結果をコピペすると罫線が
mqq とか tqq になっちゃうのを防止する