### PR TITLE
feat: git commit conventions, vimrc

### DIFF
--- a/git_commit_conventions.txt
+++ b/git_commit_conventions.txt
@@ -1,0 +1,30 @@
+# ----------------------------------------------------------
+# Header - (type): Brief description
+# ----------------------------------------------------------
+#    * feat        A new feature
+#    * fix         A bug fix
+#    * docs        Changes to documentation only
+#    * style       Style/format changes (whitespace, etc.)
+#    * refactor    Changes not related to a bug or feature
+#    * perf        Changes that affects performance
+#    * test        Changes that add/modify/correct tests
+#    * build       Changes to build system (configs, etc.)
+#    * ci          Changes to CI pipeline/workflow
+#    * chore       General tool, config, simple refactoring
+# ----------------------------------------------------------
+
+
+# ----------------------------------------------------------
+# Body - More description, if necessary
+# ----------------------------------------------------------
+#    * Motivation behind changes, more detail into how 
+#      functionality might be affected, etc.
+# ----------------------------------------------------------
+
+
+# ----------------------------------------------------------
+# Footer - Associated issues, PRs, etc.
+# ----------------------------------------------------------
+#    * Ex: Resolves Issue #207, see PR #15, etc.
+# ----------------------------------------------------------
+

--- a/gitconfig
+++ b/gitconfig
@@ -26,7 +26,7 @@
        plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format:'%t%Y/%m/%d %H:%M'  --all --graph
 
 [core]
-	editor = vi
+	editor = vim +15 +startinsert
 	autocrlf = false
 	filemode = false
 	excludesfile = ~/.gitignore_global
@@ -39,3 +39,5 @@
 
 [advice]
 	detachedHead = false
+[commit]
+	template = /home/raki/.dotfiles/git_commit_conventions.txt

--- a/vimrc
+++ b/vimrc
@@ -27,3 +27,6 @@ augroup noo
   autocmd FileType * setlocal fo-=o
 augroup END
 
+set encoding=utf-8
+set fileencodings=utf-8,iso-2022-jp,sjis
+


### PR DESCRIPTION
git commit template は使ってみただけ。
なくてもちゃんとコミット書いてるつもり。つもり。

vimrc のほうは WSL2 で Ubuntu20.04 にしたら
ファイルを開くたびに文字化けらったするので設定してみた

そういえば元記事はこちら
https://dev.to/timmybytes/keeping-git-commit-messages-consistent-with-a-custom-template-1jkm