### PR TITLE
alias: terraform version

### DIFF
--- a/alias
+++ b/alias
@@ -63,6 +63,7 @@ alias tir='terraform init -reconfigure'
 alias to='terraform output'
 alias tp='terraform plan'
 alias ts='terraform state'
+alias tv='terraform version'
 
 # waypoint
 alias wp='waypoint'


### PR DESCRIPTION
バージョンアップの過渡期で、どのディレクトリでどのバージョンが
動いてるのかを叩いて確認する機会が増えたので、
面倒になって追加

ついでの雑だけど、このリポジトリだけで使ってる header type の
alias をちゃんと守ろうと思った。。。