### PR TITLE
feat: alias greps, grep exclude # comment and empty lines

### DIFF
--- a/alias
+++ b/alias
@@ -5,6 +5,7 @@ alias ll='ls -l'
 alias tree='tree --charset unicode'
 alias myip='curl -s inet-ip.info'
 alias diff='diff --exclude=.terraform --exclude=.git'
+alias greps='grep -v -e '\''^\s*#'\'' -e '\''^\s*$'\'''
 
 # boundary 
 alias b='boundary'


### PR DESCRIPTION
grep で # で始まる行と空行を除外する alias

いちいち調べるのが面倒になってきたので。。。

単純に grep のデフォルトにすると必要な値が検索されない（コメントの文字列が拾えない）ので注意。

主に設定ファイルなどで実際に有効になる設定値だけを抜き出すなどに使える。

```
greps README.md
```