### PR TITLE
feat: use only directories when cd in bash complete

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -11,3 +11,6 @@ source $HOME/.dotfiles/history
 source $HOME/.dotfiles/peco
 source $HOME/.dotfiles/bash_functions
 
+# cd コマンドの補完でディレクトリだけを対象にする
+complete -d cd
+


### PR DESCRIPTION
https://linux.die.net/man/1/bash

cd の補完でディレクトリだけを候補にする。
ディストリビューションによっては設定済だったりするらしい。
WSL2 の Ubuntsu20 では設定されてないみたいなので追加。