### PR TITLE
Revert "feat: use only directories when cd in bash complete"

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -11,6 +11,3 @@ source $HOME/.dotfiles/history
 source $HOME/.dotfiles/peco
 source $HOME/.dotfiles/bash_functions
 
-# cd コマンドの補完でディレクトリだけを対象にする
-complete -d cd
-


### PR DESCRIPTION
Reverts officel/dotfiles#32

嘘だった。。。
cd はちゃんとディレクトリだけを対象にしてる。。。
