### PR TITLE
feat: packer Autocompletion

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -33,3 +33,6 @@ eval "$(direnv hook bash)"
 # aws cli
 complete -C '$HOME/.local/bin/aws_completer' aws
 
+# packer
+complete -C /home/linuxbrew/.linuxbrew/bin/packer packer
+


### PR DESCRIPTION
see https://www.packer.io/docs/commands#autocompletion

```
packer -autocomplete-install
```

すると入るんだけど、brew で入れているとパスの指定が実ファイルに向いてしまって
バージョンを移動した時面倒なので、手で書き替えて brew の bin に向けた。

いうほど packer の補完とか使わないけど、ずっと差分のまま放置してたのを改める。

ちなみに terraform も同じサブコマンドで入るけど、自前で alias 張ってるので必要ないから有効にしてない。