### PR TITLE
feat: alias curlh, aec2

### DIFF
--- a/alias
+++ b/alias
@@ -6,6 +6,12 @@ alias tree='tree --charset unicode'
 alias myip='curl -s inet-ip.info'
 alias diff='diff --exclude=.terraform --exclude=.git'
 alias greps='grep -v -e '\''^\s*#'\'' -e '\''^\s*$'\'''
+alias curlh='curl -D - -s -o /dev/null -sSL'
+
+# aws cli with jq
+alias aec2='aws ec2 describe-instances | jq -r '"'"'.Reservations|sort_by(.Instances[].Tags[]|select(.Key == "Name").Value)| .[].Instances[]|[(.Tags[]|select(.Key == "Name").Value), .InstanceId, .PrivateIpAddress, .State.Name] | @tsv'"'"''
+alias aec2start='aws ec2 start-instances --instance-ids'
+alias aec2stop='aws ec2 stop-instances --instance-ids'
 
 # boundary 
 alias b='boundary'


### PR DESCRIPTION
- curl でヘッダだけ取得するエイリアス
- aws cli で describe-instances して jq で整形
- aws cli で start / stop

curl のほうはアクセステスト時に本文捨てたいだけ

aec2 は aws cli コマンドの alias を積もうと思って始めた。

```
aec2 | grep hoge
aec2start i-xxxxxxxx
aec2stop i-xxxxxxxx
```

作業用ディレクトリ（インフラ用リポジトリ下）は概ね direnv で aws のセットアップしているのでしゅっと使える。