### PR TITLE
alias: ansible-playbook about logging

### DIFF
--- a/alias
+++ b/alias
@@ -8,6 +8,9 @@ alias diff='diff --exclude=.terraform --exclude=.git'
 alias greps='grep -v -e '\''^\s*#'\'' -e '\''^\s*$'\'''
 alias curlh='curl -D - -s -o /dev/null -sSL'
 
+# ansible
+alias ansible-playbook='ANSIBLE_LOG_PATH=logs/ansible_$(date "+%Y%m%d%H%M%S").log ansible-playbook'
+
 # aws cli with jq
 alias aec2='aws ec2 describe-instances | jq -r '"'"'.Reservations|sort_by(.Instances[].Tags[]|select(.Key == "Name").Value)| .[].Instances[]|[(.Tags[]|select(.Key == "Name").Value), .InstanceId, .PrivateIpAddress, .State.Name] | @tsv'"'"''
 alias aec2start='aws ec2 start-instances --instance-ids'


### PR DESCRIPTION
direnv で環境変数に ansible log path を設定しているんだけど、
export してしまうとログインしたタイミング（exportしたタイミング）の
ファイルに常に追記になってしまって見にくいので、実行毎のログファイルに
なるように alias を指定することにした。

実行ディレクトリに logs ディレクトリがないとエラーになるので、
/tmp とか /var/log あたりに出力してもいい気がするけど、
そうすると今度はリポジトリ毎のファイル名とかつけたくなってしまうので
一旦見送ることにした。