### PR TITLE
feat: no need git_commit_conventions.txt from git config

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -26,7 +26,8 @@
        plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format:'%t%Y/%m/%d %H:%M'  --all --graph
 
 [core]
-	editor = vim +15 +startinsert
+	# editor = vim +15 +startinsert
+	editor = vim +startinsert
 	autocrlf = false
 	filemode = false
 	excludesfile = ~/.gitignore_global
@@ -40,4 +41,4 @@
 [advice]
 	detachedHead = false
 [commit]
-	template = /home/raki/.dotfiles/git_commit_conventions.txt
+	# template = /home/raki/.dotfiles/git_commit_conventions.txt


### PR DESCRIPTION
コミット時のヘッダ設定にも慣れたのと、行数をもっていかれすぎて
差分確認のためにスクロールしないといけないのが面倒になってきたので
お役御免ということにした。