### PR TITLE
feat(git): git config --global log.follow true

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -42,3 +42,5 @@
 	detachedHead = false
 [commit]
 	# template = /home/raki/.dotfiles/git_commit_conventions.txt
+[log]
+	follow = true


### PR DESCRIPTION
https://twitter.com/raki/status/1452464172675973124

github でリネーム前のファイルも含めて追跡したかったんだけど、一発でやるのは無理っぽい。
代わりじゃないけど --follow をつけなくても自動でフォローしてくれる設定を見つけたのでつけた。

```
git log -- filename
```