### PR TITLE
fix: about aws-vault. rm func, new alias w/z terraform

### DIFF
--- a/alias
+++ b/alias
@@ -16,6 +16,19 @@ alias aec2='aws ec2 describe-instances | jq -r '"'"'.Reservations|sort_by(.Insta
 alias aec2start='aws ec2 start-instances --instance-ids'
 alias aec2stop='aws ec2 stop-instances --instance-ids'
 
+# aws-vault
+alias av='aws-vault'
+alias avc='aws-vault clear'
+alias ave='aws-vault exec'
+alias avls='aws-vault list'
+
+# aws-vault & terraform
+alias avta='aws-vault exec ${AWS_PROFILE:-default} -- terraform apply'
+alias avte='aws-vault exec ${AWS_PROFILE:-default} -- terraform init --upgrade && aws-vault exec ${AWS_PROFILE:-default} -- terraform fmt && aws-vault exec ${AWS_PROFILE:-default} -- terraform plan'
+alias avto='aws-vault exec ${AWS_PROFILE:-default} -- terraform output'
+alias avtp='aws-vault exec ${AWS_PROFILE:-default} -- terraform plan'
+alias avts='aws-vault exec ${AWS_PROFILE:-default} -- terraform state'
+
 # boundary 
 alias b='boundary'
 

--- a/bash_functions
+++ b/bash_functions
@@ -18,8 +18,3 @@ function jqp {
   fi
 }
 
-function av {
-  profile=$1; shift
-  aws-vault exec $profile -- "$@";
-}
-


### PR DESCRIPTION
func av は 他の aws-vault サブコマンドも使いたいのでやめることにした。
（１日。。。）

alias のほうは予定調和で aws-vault を av にした。
オーディオ系使うような仕事してないしね。
terraform を使う時もデフォルトで置き換えちゃうのがいいかと思ったんだけど
今動かしてるやつが引っかかると手間なので、移行期間中として avtX とした。

avetX にするのが正な気もするけど、5文字はタイプしたくないのでeは取った。
赤毛のアンとは違うのですよｗ

各ディレクトリの .envrc でアクセスキーを設定してるところを
AWS_PROFILE に指定しなおすことで動作するのを確認してる。