### PR TITLE
feat: git config quotepath, ignorecase

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -31,6 +31,9 @@
 	autocrlf = false
 	filemode = false
 	excludesfile = ~/.gitignore_global
+        quotepath  = false
+        ignorecase = false
+
 [fetch]
 	prune = true
 [help]


### PR DESCRIPTION
日本語ファイル（非アスキー文字列のファイル）のファイル名の文字化け（エンコード）対策

```
git config --global core.quotepath false
```

ファイル名の大文字と小文字を区別する

```
git config --global core.ignorecase false
```