### PR TITLE
feat: git alias pr

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -20,6 +20,7 @@
        cancel = reset --soft HEAD^
        save   = stash save
        load   = stash pop
+       pr     = "!git push origin HEAD:refs/heads/$1 #"
 
        # options
        alias  = !git config --get-regexp 'alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort


### PR DESCRIPTION
ローカルブランチを作らなくなってだいぶ経つけど、実はずっと面倒だった push

```
g push origin HEAD:refs/heads/new_branch
```

これは

- git の refspec で refs/heads (or tags) がないとブランチとタグを区別できない
- ローカルブランチを作らない
- bash alias で引数が受けられない（受けてもスペースが入るので使えない）

のが原因だった。

git alias なら引数を受けてもスペースが入らないので個人的な使い方、つまり

- ローカルブランチをいちいち作らない
- 何度もブランチ名を打ちたくない
- 現在の HEAD で（githubに） PR を投げたい

が実現できると思ってやってみた。

```
gr
vi file
ga file
gcv
g pr feat/branch
```

でいけるようになった！