### PR TITLE
fix(vimrc): ignorecase, cursor change for windows terminal

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -4,7 +4,11 @@ set history=1000
 set ruler     " Show the line and column number of the cursor position
 set showcmd   " Show (partial) command in the last line of the screen
 
+" 自動インデントモード（autoindent）
 set noai
+
+" 大文字小文字を区別しないで検索（ignorecase）
+set ic
 
 " visual
 set number
@@ -29,4 +33,14 @@ augroup END
 
 set encoding=utf-8
 set fileencodings=utf-8,iso-2022-jp,sjis
+
+" https://qiita.com/Linda_pp/items/9e0c94eb82b18071db34
+if has('vim_starting')
+    " 挿入モード時に非点滅の縦棒タイプのカーソル
+    let &t_SI .= "\e[6 q"
+    " ノーマルモード時に非点滅のブロックタイプのカーソル
+    let &t_EI .= "\e[2 q"
+    " 置換モード時に非点滅の下線タイプのカーソル
+    let &t_SR .= "\e[4 q"
+endif
 


### PR DESCRIPTION
大文字小文字を区別しないで検索するようにした。
コメントにいれたけど Windows Terminal で vi 使う時のカーソルモードを変更した。