### PR TITLE
feat: show full date time on tmux status bar

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -15,6 +15,8 @@ set -g status-style "bg=cyan,fg=black"
 set -g window-status-style "bg=cyan,fg=black"
 set -g window-status-current-style "bg=black,fg=blue"
 
+set -g status-right "%Y/%m/%d %a %H:%M "
+
 # key
 
 # | でペインを立てに分割する
@@ -42,5 +44,6 @@ bind V select-layout main-vertical \; swap-pane -s : -t 0 \; select-pane -t 0 \;
 bind H select-layout main-horizontal \; swap-pane -s : -t 0 \; select-pane -t 0 \; resize-pane -D 15
 
 # Other options
+# see https://superuser.com/questions/295736/tmux-status-bar-messages-last-only-about-a-second-can-i-extend-this
 set-option -g display-time 2000
 


### PR DESCRIPTION
Windows 11 にしてタスクバーがあんまりひどくて非表示にしたので
代わりに tmux に表示される時刻を見やすくしておこうかと。