### PR TITLE
fix: set nonumber on vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -11,7 +11,7 @@ set noai
 set ic
 
 " visual
-set number
+set nonumber
 " set list      " Show tabs as CTRL-I is displayed
 
 " search


### PR DESCRIPTION
wsl2 で vi を開いたときに行番号を表示していると表示が崩れる
ケースが多いので nonu にすることにした。