### PR TITLE
feat: git grep lineNumber = true

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -50,3 +50,5 @@
 	follow = true
 [init]
 	defaultBranch = main
+[grep]
+	lineNumber = true


### PR DESCRIPTION
git grep の alias は gg にしてあるけど、
見つかったファイルの行番号を表示するようにするフラグをオンにした。