### PR TITLE
feat: alias pwgen

### DIFF
--- a/alias
+++ b/alias
@@ -7,6 +7,7 @@ alias myip='curl -s inet-ip.info'
 alias diff='diff --exclude=.terraform --exclude=.git'
 alias greps='grep -v -e '\''^\s*#'\'' -e '\''^\s*$'\'''
 alias curlh='curl -D - -s -o /dev/null -sSL'
+alias pwgen='pwgen -c -n -B -1'
 
 # ansible
 alias ansible-playbook='ANSIBLE_LOG_PATH=logs/ansible_$(date "+%Y%m%d%H%M%S").log ansible-playbook'


### PR DESCRIPTION
ubuntu に mkpasswd が入っていないのでかわりに pwgen をインストール。
デフォルトがてらの設定。

-c : 最低一文字の大文字を含める
-n : 最低一文字の数値を含める
-y : 最低一文字の記号を含める
-B : 1（イチ）やl（エル）、O（オー）、0（ゼロ）など紛らわしい文字は含めない
-1 : 1行あたり1パスワード表示する

記号はデフォルトでは使わないようにしておく（ダブルクォーテーション等使いたくない文字を -r で除外するのが面倒）

使い方的には以下のようにできる

```
pwgen 16 -y 10
```