### PR TITLE
feat: eval ssh-agent on WSL

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -11,3 +11,8 @@ source $HOME/.dotfiles/history
 source $HOME/.dotfiles/peco
 source $HOME/.dotfiles/bash_functions
 
+# ssh-agent for git commit ssh signature verification
+if [ -z "${SSH_AGENT_PID}" ]; then
+    eval $(ssh-agent) 1>/dev/null
+fi
+


### PR DESCRIPTION
ログイン時に ssh-agent を起動させる

- WSL でしか必要ない気がする
- ssh-agent が起動していなかったら eval して鍵を登録する
- 確認は `ssh-add -l`
- そもそもは github の verify 向け
- https://github.com/officel/config_git/pull/7