### PR TITLE
feat: alias fullpath

### DIFF
--- a/alias
+++ b/alias
@@ -8,6 +8,7 @@ alias diff='diff --exclude=.terraform --exclude=.git'
 alias greps='grep -v -e '\''^\s*#'\'' -e '\''^\s*$'\'''
 alias curlh='curl -D - -s -o /dev/null -sSL'
 alias pwgen='pwgen -c -n -B -1'
+alias fullpath='find `pwd` -maxdepth 1 -name'
 
 # ansible
 alias ansible-playbook='ANSIBLE_LOG_PATH=logs/ansible_$(date "+%Y%m%d%H%M%S").log ansible-playbook'


### PR DESCRIPTION
カレントディレクトリのファイルのフルパスが取得したい

```
// 案1
$ ls -1 `pwd`/alias
/home/raki/.dotfiles/alias

// 案2
$ readlink -f alias
/home/raki/.dotfiles/alias

// 案3
$ find `pwd` -maxdepth 1 -name alias
/home/raki/.dotfiles/alias
```

- 案1は補完が効かない（バッククォートとスラッシュとファイル名はくっついている）のと、alias にしにくい（ファイル名）
- 案2なら alias にするまでもないのと、そもそもシンボリックリンクを辿るコマンドなので、実パスになってしまう
- 案3は alias にする意味がある長さとオプションだしファイル名を後ろにつけて使う使い方に適している