### PR TITLE
feat: alias ansible-groups

### DIFF
--- a/alias
+++ b/alias
@@ -12,6 +12,7 @@ alias fullpath='find `pwd` -maxdepth 1 -name'
 
 # ansible
 alias ansible-playbook='ANSIBLE_LOG_PATH=logs/ansible_$(date "+%Y%m%d%H%M%S").log ansible-playbook'
+alias ansible-groups='ansible-inventory --list | jq -r "keys | .[]"'
 
 # aws cli with jq
 alias aec2='aws ec2 describe-instances | jq -r '"'"'.Reservations|sort_by(.Instances[].Tags[]|select(.Key == "Name").Value)| .[].Instances[]|[(.Tags[]|select(.Key == "Name").Value), .InstanceId, .PrivateIpAddress, .State.Name] | @tsv'"'"''


### PR DESCRIPTION
ansible-inventory コマンドでグループだけ抜き出すとかやりたいんだけど
うまいことできなかったので、jq に頼ることにした。

ansible- コマンド類は単数形呼び出しって決まっている（inventory も playbook も）ので 複数形にしておくことでバッティングを予防しつつわかりやすくできた。