### PR TITLE
test: gitignore partical

### DIFF
--- a/alias
+++ b/alias
@@ -25,6 +25,7 @@ alias av='aws-vault'
 alias avc='aws-vault clear'
 alias ave='aws-vault exec'
 alias avls='aws-vault list'
+#gitignore で終わる行を ignore してみた
 
 # aws-vault & terraform
 alias avta='aws-vault exec ${AWS_PROFILE:-default} -- terraform apply'


### PR DESCRIPTION
コミットに含めたくない行がある時に、部分的に無視（ignore）できないか調べた。

https://stackoverflow.com/questions/16244969/how-to-tell-git-to-ignore-individual-lines-i-e-gitignore-for-specific-lines-of

今回は具体的には業務用の alias を無視するようにした。

コミットにはその行が含まれていない。

```
.dotfiles $ cat .git/info/attributes
alias filter=gitignore
.dotfiles $ cat .git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
[remote "origin"]
        url = git@github.com:officel/dotfiles.git
        fetch = +refs/heads/*:refs/remotes/origin/*
[filter "gitignore"]
        clean = "sed '/#gitignore$/d'"
        smudge = cat
```

指定のファイル（*.txtなどとしてよい。今回はローカルの alias だけ）に対して、
gitignore という名前のフィルタを適用する指示を出し、
（今回はローカルのリポジトリだけなので）ローカルの config に処理を書いた。

今のところ問題なく動いているように見えるが、checkout, rebase, pull で
ダメになるっぽいので、それを確認する。