### PR TITLE
feat: alias for wsl useyq, usepyq

### DIFF
--- a/alias_wsl
+++ b/alias_wsl
@@ -2,3 +2,7 @@
 
 # command
 alias pbcopy='clip.exe'
+
+# yq & python-yq installed by brew, switch to use.
+alias usepyq='brew unlink yq python-yq && brew link python-yq && yq --version'
+alias useyq=' brew unlink yq python-yq && brew link yq        && yq --version'


### PR DESCRIPTION
https://twitter.com/raki/status/1593280424939491328

WSL2 Ubuntu で brew を使っているんだけど、yq の formulae が２つあって、 それらを入れ替えて使えるようにした。

リンク先にも書いたけど、古いバージョンの brew だと switch サブコマンドが
あって、旧バージョンの formulae を切り替えて使えたらしい。

今は無くなってしまったようなので、unlink & link って形で、
alternatives と同じようなことをしてみた。