### PR TITLE
fix: alias docker-compose to docker compose

### DIFF
--- a/alias
+++ b/alias
@@ -51,9 +51,9 @@ alias alpinx='docker container run -itd --rm -v `pwd`:/usr/share/nginx/html -p 8
 alias alpython='docker container run --rm -it -d -e "TZ=Asia/Tokyo" --name alpython python:alpine'
 alias jekyll='docker container run -itd --rm -v `pwd`:/srv/jekyll:Z -e "TZ=Asia/Tokyo" --name jekyll jekyll/jekyll jekyll'
 
-alias dc='docker-compose'
-alias dcd='docker-compose down'
-alias dcu='docker-compose up -d'
+alias dc='docker compose'
+alias dcd='docker compose down'
+alias dcu='docker compose up -d'
 
 # git
 alias g='git'


### PR DESCRIPTION
時間のあるうちに手直ししておかないとね。
Compose v2 対応で `docker-compose` を使わないで `docker compose` を使うってね。

see https://qiita.com/zembutsu/items/d82b2ae1a511ebd6a350

手持ちの docker-compose.yml は概ね v3 使用だから特に手を加えなくても問題ないはず？

```bash
.dotfiles $ docker compose version
Docker Compose version v2.15.1
```