### PR TITLE
fix: alias ghome to cr

### DIFF
--- a/alias
+++ b/alias
@@ -74,7 +74,7 @@ alias gpr='git pr'
 alias gr='git fetch --prune --all && git checkout origin/HEAD && git plog -10 && git status'
 alias gs='git switch -d origin/HEAD'
 alias gst='git status --short --branch'
-alias ghome='cd "$(git rev-parse --show-toplevel)"'
+alias cr='cd "$(git rev-parse --show-toplevel)"'
 
 # k8s
 alias k='kubectl'


### PR DESCRIPTION
ghome をタイプするのが面倒になってきたので、cd と同じ要領で使えるように
Change Repository で `cr` にすることにした。楽ちん。

gh は github cli と被るし、cg は CG をイメージするし、 gc はガベージコレクションだし。