### PR TITLE
fix: alias ansible-playbook use environment LC_ALL, TZ

### DIFF
--- a/alias
+++ b/alias
@@ -12,7 +12,7 @@ alias pwgen='pwgen -c -n -B -1'
 alias fullpath='find `pwd` -maxdepth 1 -name'
 
 # ansible
-alias ansible-playbook='ANSIBLE_LOG_PATH=logs/ansible_$(date "+%Y%m%d%H%M%S").log ansible-playbook'
+alias ansible-playbook='LC_ALL=en_US.UTF8 TZ="Asia/Tokyo" ANSIBLE_LOG_PATH=logs/ansible_$(date "+%Y%m%d%H%M%S").log ansible-playbook'
 alias ansible-groups='ansible-inventory --list | jq -r "keys | .[]"'
 
 # aws cli with jq


### PR DESCRIPTION
ansible のバージョンを上げたら crop_columns callback plugin が死んでしまったので（別で修正した） そのついでに profile_tasks plugin の時刻表示をローカル設定にするのを調べた。

LC_ALL も TZ も普段は設定してなくて、それで困っていなかったので、他に影響があると面倒だし 実行時だけ有効にするなら alias が楽なので設定しておくことにした。

出力は英語表記で日本時間になる。
ログファイルの日付はタイムゾーンが出力されていないのでどうかとも思ったんだけど、
profile_tasks の出力に追加されているのと合わせて見れば迷わないのでいいかなと。