### PR TITLE
fix: use english weekday name in tmux status bar

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -15,7 +15,8 @@ set -g status-style "bg=cyan,fg=black"
 set -g window-status-style "bg=cyan,fg=black"
 set -g window-status-current-style "bg=black,fg=blue"
 
-set -g status-right "%Y/%m/%d %a %H:%M "
+# set -g status-right "%Y/%m/%d %a %H:%M "
+set -g status-right '#(LC_TIME="en_US.utf8" date "+%%Y/%%m/%%d %%a %%H:%%M ")'
 
 # key
 


### PR DESCRIPTION
locale の設定が日本語だと `土` のように表示されるんだけど、英語表記にしたかったのでいじってみた。

setenv で LC_TIME や LC_ALL をセットしてみたんだけどエラーになってしまって解決できなかったので stackoverflow で見つけた力技で対処。