### PR TITLE
feat: alias aw, awc, awclear

### DIFF
--- a/alias
+++ b/alias
@@ -19,6 +19,9 @@ alias ansible-groups='ansible-inventory --list | jq -r "keys | .[]"'
 alias aec2='aws ec2 describe-instances | jq -r '"'"'.Reservations|sort_by(.Instances[].Tags[]|select(.Key == "Name").Value)| .[].Instances[]|[(.Tags[]|select(.Key == "Name").Value), .InstanceId, .PrivateIpAddress, .State.Name] | @tsv'"'"''
 alias aec2start='aws ec2 start-instances --instance-ids'
 alias aec2stop='aws ec2 stop-instances --instance-ids'
+alias aw='aws sts get-caller-identity || (aws sso login --profile default && aws sts get-caller-identity)'
+alias awclear='rm -f ~/.aws/*/cache/*'
+alias awc='rm -f ~/.aws/*/cache/*; aws sso login --profile default && aws sts get-caller-identity'
 
 # aws-vault
 alias av='aws-vault'


### PR DESCRIPTION
職場のリポジトリの aws アクセスを sso に移行していて、コマンド実行時にセッションが切れていて やり直しになるのがうっとおしいので、チェックしてセッションが切れていたら再ログイン（`aw`）、
動確用にセッションを削除（`awclear`）、どうせなら常に再ログインしなおせば手っ取り早い（`awc`）を用意した。