### PR TITLE
fix: alias ls='LANG=C ls --group-directories-first'

### DIFF
--- a/alias
+++ b/alias
@@ -1,6 +1,7 @@
 # .dotfiles/alias
 
 # command
+alias ls='LANG=C ls --group-directories-first'
 alias ll='ls -l'
 alias lla='ls -al'
 alias tree='tree --charset unicode -aNI ".git|node_modules|.terraform"'


### PR DESCRIPTION
- ls -la の出力結果のソートがなんか違うなって
- github のソート順もこれっぽいのであわせる
- LANG を指定しないとマルチバイトなファイル名の時に齟齬がでる？
- 個人的にはlinuxな環境でマルチバイトなファイル名を使わないので一旦これで